### PR TITLE
Added Audit Columns for ExcessRainfalls and Farms.

### DIFF
--- a/NMP-Database/NMP-Database/DBO/Tables/ExcessRainfalls.sql
+++ b/NMP-Database/NMP-Database/DBO/Tables/ExcessRainfalls.sql
@@ -4,7 +4,14 @@
 	[Year] INT NOT NULL, 
     [ExcessRainfall] INT NULL CONSTRAINT DF_ExcessRainfalls_ExcessRainfall DEFAULT 0, 
     [WinterRainfall] INT NULL,
+    [CreatedOn] DATETIME2 NULL DEFAULT GETDATE(), 
+    [CreatedByID] INT NULL, 
+    [ModifiedOn] DATETIME2 NULL, 
+    [ModifiedByID] INT NULL, 
     CONSTRAINT [PK_ExcessRainfall] PRIMARY KEY CLUSTERED ([FarmID],[Year] ASC),    
-    CONSTRAINT [FK_ExcessRainfall_Farms] FOREIGN KEY([FarmID]) REFERENCES [dbo].[Farms] ([ID])
+    CONSTRAINT [FK_ExcessRainfall_Farms] FOREIGN KEY([FarmID]) REFERENCES [dbo].[Farms] ([ID]),
+    CONSTRAINT [FK_ExcessRainfall_Users_CreatedBy] FOREIGN KEY([CreatedByID]) REFERENCES [dbo].[Users] ([ID]),
+    CONSTRAINT [FK_ExcessRainfall_Users_ModifiedBy] FOREIGN KEY([ModifiedByID]) REFERENCES [dbo].[Users] ([ID])
+
 );
 

--- a/NMP-Database/NMP-Database/DBO/Tables/Farms.sql
+++ b/NMP-Database/NMP-Database/DBO/Tables/Farms.sql
@@ -18,12 +18,18 @@
     [Rainfall]           INT             NULL,
     [TotalFarmArea]      DECIMAL (18, 4) NOT NULL CONSTRAINT DF_Farms_TotalFarmArea DEFAULT 0,
     [AverageAltitude]    INT             NOT NULL CONSTRAINT DF_Farms_AverageAltitude DEFAULT 0,
-    [RegistredOrganicProducer] BIT       NOT NULL CONSTRAINT DF_Farms_RegistredOrganicProducer DEFAULT 0,
+    [RegisteredOrganicProducer] BIT       NOT NULL CONSTRAINT DF_Farms_RegistredOrganicProducer DEFAULT 0,
     [MetricUnits]        BIT             NOT NULL CONSTRAINT DF_Farms_MetricUnits DEFAULT 0,
     [EnglishRules]       BIT             NOT NULL CONSTRAINT DF_Farms_EnglishRules DEFAULT 1,
     [NVZFields]          INT             NOT NULL CONSTRAINT DF_Farms_NVZFields DEFAULT 0,
-    [FieldsAbove300SeaLevel]   INT       NOT NULL CONSTRAINT DF_Farms_FieldsAbove300SeaLevel DEFAULT 0
-    CONSTRAINT [PK_Farms] PRIMARY KEY ([ID] ASC)
+    [FieldsAbove300SeaLevel]   INT       NOT NULL CONSTRAINT DF_Farms_FieldsAbove300SeaLevel DEFAULT 0,
+    [CreatedOn] DATETIME2 NULL DEFAULT GETDATE(), 
+    [CreatedByID] INT NULL, 
+    [ModifiedOn] DATETIME2 NULL, 
+    [ModifiedByID] INT NULL,
+    CONSTRAINT [PK_Farms] PRIMARY KEY ([ID] ASC),
+    CONSTRAINT [FK_Farms_Users_CreatedBy] FOREIGN KEY([CreatedByID]) REFERENCES [dbo].[Users] ([ID]),
+    CONSTRAINT [FK_Farms_Users_ModifiedBy] FOREIGN KEY([ModifiedByID]) REFERENCES [dbo].[Users] ([ID])
 
 
 )

--- a/NMP-Database/NMP-Database/NMP-Database.refactorlog
+++ b/NMP-Database/NMP-Database/NMP-Database.refactorlog
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Operations Version="1.0" xmlns="http://schemas.microsoft.com/sqlserver/dac/Serialization/2012/02">
+  <Operation Name="Rename Refactor" Key="e977c725-7365-4a6b-80ba-fe03d7a653ea" ChangeDateTime="04/11/2024 09:11:59">
+    <Property Name="ElementName" Value="[dbo].[Farms].[CreatedByID]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[Farms]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="CreatedOn" />
+  </Operation>
+  <Operation Name="Rename Refactor" Key="06a5e69b-5f55-4b79-83bc-91c026e1600d" ChangeDateTime="04/11/2024 09:12:04">
+    <Property Name="ElementName" Value="[dbo].[Farms].[Created]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[Farms]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="CreatedByID" />
+  </Operation>
+</Operations>

--- a/NMP-Database/NMP-Database/NMP-Database.sqlproj
+++ b/NMP-Database/NMP-Database/NMP-Database.sqlproj
@@ -72,4 +72,7 @@
   <ItemGroup>
     <PreDeploy Include="Script.PreDeployment.sql" />
   </ItemGroup>
+  <ItemGroup>
+    <RefactorLog Include="NMP-Database.refactorlog" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
# Audit Columns Added for Excess Rainfalls and Farms

## Columns added
- CreatedOn
- CreatedByID (with FK constraint to Users table)
- ModifedOn
- ModifiedByID (with FK constraint to Users table).

## Important Change
- Corrected spelling mistake for RegisteredOrganicProvider column was previously "RegistredOrganicProvider". If we are hard coding the mapping in any way in the code, please look to update this in the code. 


## Branch can be deleted when merged